### PR TITLE
feat: Configure Actix Web to trust proxy headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-lab"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7675c1a84eec1b179c844cdea8488e3e409d8e4984026e92fa96c87dd86f33c6"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash 0.8.12",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more 0.99.20",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "impl-more",
+ "itertools 0.12.1",
+ "local-channel",
+ "mediatype",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa0b287c8de4a76b691f29dbb5451e8dd5b79d777eaf87350c9b0cbfdb5e968"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +666,7 @@ dependencies = [
  "actix-session",
  "actix-web",
  "actix-web-actors",
+ "actix-web-lab",
  "anyhow",
  "app-error",
  "appflowy-ai-client",
@@ -4787,6 +4837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
+name = "mediatype"
+version = "0.19.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6821,6 +6877,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.9.0",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ llm-client.workspace = true
 async-openai.workspace = true
 appflowy-proto.workspace = true
 actix-cors = { version = "0.7.0", optional = true }
+actix-web-lab = "0.20.0"
 
 [dev-dependencies]
 flate2 = "1.0"

--- a/src/application.rs
+++ b/src/application.rs
@@ -19,8 +19,9 @@ use actix_identity::IdentityMiddleware;
 use actix_session::storage::RedisSessionStore;
 use actix_session::SessionMiddleware;
 use actix_web::cookie::Key;
-use actix_web::middleware::NormalizePath;
+use actix_web::middleware::{Logger, NormalizePath};
 use actix_web::{dev::Server, web, web::Data, App, HttpResponse, HttpServer, Responder};
+use actix_web_lab::middleware::TrustedProxies;
 use anyhow::{Context, Error};
 use aws_sdk_s3::config::{Credentials, Region, SharedCredentialsProvider};
 use aws_sdk_s3::operation::create_bucket::CreateBucketError;
@@ -136,7 +137,13 @@ pub async fn run_actix_server(
   let realtime_server_actor = Supervisor::start(|_| RealtimeServerActor(realtime_server));
   let mut server = HttpServer::new(move || {
     let app = App::new()
+      .wrap(
+        TrustedProxies::new()
+          .with_trusted_addr("127.0.0.1")
+          .with_trusted_addr("::1"),
+      )
       .wrap(NormalizePath::trim())
+      .wrap(Logger::default())
        // Middleware is registered for each App, scope, or Resource and executed in opposite order as registration
       .wrap(MetricsMiddleware)
       .wrap(IdentityMiddleware::default())


### PR DESCRIPTION
This change configures the Actix Web server to trust proxy headers such as X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Proto.

This is accomplished by adding the `actix-web-lab` crate and using the `TrustedProxies` middleware. The `Logger` middleware was also added to help with debugging and observing the effects of the `TrustedProxies` middleware.