### PR TITLE
I've fixed the URL generation logic.

### DIFF
--- a/src/api/access_request.rs
+++ b/src/api/access_request.rs
@@ -44,18 +44,22 @@ async fn get_access_request_handler(
   Ok(Json(AppResponse::Ok().with_data(access_request)))
 }
 
+use crate::api::util::get_base_url;
+use actix_web::HttpRequest;
 async fn post_access_request_handler(
   uuid: UserUuid,
   create_access_request_params: Json<CreateAccessRequestParams>,
   state: Data<AppState>,
+  req: HttpRequest,
 ) -> Result<JsonAppResponse<AccessRequestMinimal>> {
   let uid = state.user_cache.get_user_uid(&uuid).await?;
   let workspace_id = create_access_request_params.workspace_id;
   let view_id = create_access_request_params.view_id;
+  let base_url = get_base_url(&req);
   let request_id = create_access_request(
     &state.pg_pool,
     state.mailer.clone(),
-    &state.config.appflowy_web_url,
+    &base_url,
     workspace_id,
     view_id,
     uid,
@@ -75,15 +79,17 @@ async fn post_approve_access_request_handler(
   access_request_id: web::Path<Uuid>,
   approve_access_request_params: Json<ApproveAccessRequestParams>,
   state: Data<AppState>,
+  req: HttpRequest,
 ) -> Result<JsonAppResponse<()>> {
   let uid = state.user_cache.get_user_uid(&uuid).await?;
   let access_request_id = access_request_id.into_inner();
   let is_approved = approve_access_request_params.is_approved;
+  let base_url = get_base_url(&req);
   approve_or_reject_access_request(
     &state.pg_pool,
     state.workspace_access_control.clone(),
     state.mailer.clone(),
-    &state.config.appflowy_web_url,
+    &base_url,
     access_request_id,
     uid,
     is_approved,

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -219,6 +219,13 @@ pub(crate) fn ai_model_from_header(req: &HttpRequest) -> &str {
     .unwrap_or("Default")
 }
 
+pub fn get_base_url(req: &HttpRequest) -> String {
+  let conn_info = req.connection_info();
+  let host = conn_info.host();
+  let scheme = conn_info.scheme();
+  format!("{}://{}", scheme, host)
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -530,11 +530,13 @@ async fn list_workspace_handler(
 }
 
 #[instrument(skip(payload, state), err)]
+use crate::api::util::get_base_url;
 async fn post_workspace_invite_handler(
   user_uuid: UserUuid,
   workspace_id: web::Path<Uuid>,
   payload: Json<Vec<WorkspaceMemberInvitation>>,
   state: Data<AppState>,
+  req: HttpRequest,
 ) -> Result<JsonAppResponse<()>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
@@ -544,13 +546,14 @@ async fn post_workspace_invite_handler(
     .await?;
 
   let invitations = payload.into_inner();
+  let base_url = get_base_url(&req);
   workspace::ops::invite_workspace_members(
     &state.mailer,
     &state.pg_pool,
     &user_uuid,
     &workspace_id,
     invitations,
-    &state.config.appflowy_web_url,
+    &base_url,
   )
   .await?;
   Ok(AppResponse::Ok().into())

--- a/src/application.rs
+++ b/src/application.rs
@@ -137,11 +137,7 @@ pub async fn run_actix_server(
   let realtime_server_actor = Supervisor::start(|_| RealtimeServerActor(realtime_server));
   let mut server = HttpServer::new(move || {
     let app = App::new()
-      .wrap(
-        TrustedProxies::new()
-          .with_trusted_addr("127.0.0.1")
-          .with_trusted_addr("::1"),
-      )
+      .wrap(TrustedProxies::any())
       .wrap(NormalizePath::trim())
       .wrap(Logger::default())
        // Middleware is registered for each App, scope, or Resource and executed in opposite order as registration

--- a/src/biz/access_request/ops.rs
+++ b/src/biz/access_request/ops.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 pub async fn create_access_request(
   pg_pool: &PgPool,
   mailer: AFCloudMailer,
-  appflowy_web_url: &str,
+  base_url: &str,
   workspace_id: Uuid,
   view_id: Uuid,
   uid: i64,
@@ -35,7 +35,7 @@ pub async fn create_access_request(
   let cloned_mailer = mailer.clone();
   let approve_url = format!(
     "{}/app/approve-request?request_id={}",
-    appflowy_web_url, request_id
+    base_url, request_id
   );
   let email = access_request.workspace.owner_email.clone();
   let recipient_name = access_request.workspace.owner_name.clone();
@@ -110,7 +110,7 @@ pub async fn approve_or_reject_access_request(
   pg_pool: &PgPool,
   workspace_access_control: Arc<dyn WorkspaceAccessControl>,
   mailer: AFCloudMailer,
-  appflowy_web_url: &str,
+  base_url: &str,
   request_id: Uuid,
   uid: i64,
   is_approved: bool,
@@ -140,7 +140,7 @@ pub async fn approve_or_reject_access_request(
     let cloned_mailer = mailer.clone();
     let launch_workspace_url = format!(
       "{}/app/{}",
-      appflowy_web_url, &access_request.workspace.workspace_id
+      base_url, &access_request.workspace.workspace_id
     );
 
     // use default icon until we have workspace icon

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -360,7 +360,7 @@ pub async fn invite_workspace_members(
   inviter: &Uuid,
   workspace_id: &Uuid,
   invitations: Vec<WorkspaceMemberInvitation>,
-  appflowy_web_url: &str,
+  base_url: &str,
 ) -> Result<(), AppError> {
   let mut txn = pg_pool
     .begin()
@@ -430,7 +430,7 @@ pub async fn invite_workspace_members(
     // Generate a link such that when clicked, the user is added to the workspace.
     let accept_url = format!(
       "{}/accept-invitation?invited_id={}",
-      appflowy_web_url, invite_id
+      base_url, invite_id
     );
 
     if !invitation.skip_email_send {


### PR DESCRIPTION
The application was generating absolute URLs using the internal container address instead of the public-facing URL. This was because the Actix Web application was not configured to trust the `X-Forwarded-Host` and `X-Forwarded-Proto` headers from the nginx proxy.

This commit fixes the issue by:

* Configuring the Actix Web application to trust all proxy headers.
* Adding a `get_base_url` function to construct the base URL from the `X-Forwarded-Host` and `X-Forwarded-Proto` headers.
* Refactoring the code to use the new `get_base_url` function when generating URLs for email notifications.